### PR TITLE
Change the structure of third-party script rendering

### DIFF
--- a/src/script-rendering.php
+++ b/src/script-rendering.php
@@ -16,6 +16,44 @@ function mtps_head_scripts() {
     $cookiebot_no_head     = mtps_get_field_value( 'mtps_cookiebot_no_head' );
     $cookiebot_field_value = mtps_get_field_value( 'mtps_cookiebot_field' );
     $cookiebot_id          = apply_filters( 'mtps_cookiebot_id', $cookiebot_field_value );
+
+    if ( $cookiebot_id && $cookiebot_no_head !== '1' ) {
+        $current_locale = substr( get_locale(), 0, 2 );
+        $cookiebot_code = '<script async id="Cookiebot" data-culture="' . esc_attr( $current_locale ) . '" src="https://consent.cookiebot.com/uc.js" data-cbid="' . esc_attr( $cookiebot_id ) . '" data-blockingmode="auto"></script>';
+        $cookiebot_code = apply_filters( 'mtps_cookiebot_code', $cookiebot_code, $cookiebot_id );
+        // phpcs:disable
+        echo $cookiebot_code;
+        // phpcs:enable
+
+        // If we have Cookiebot in use, we need to set the consent mode.
+        $cookiebot_consent_mode = "
+            <!-- Google Consent Mode -->
+            <script data-cookieconsent='ignore' async>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments)
+            }
+            gtag('consent', 'default', {
+                ad_personalization: 'denied',
+                ad_storage: 'denied',
+                ad_user_data: 'denied',
+                analytics_storage: 'denied',
+                functionality_storage: 'granted',
+                personalization_storage: 'denied',
+                security_storage: 'granted',
+                wait_for_update: 500
+            });
+            gtag('set', 'ads_data_redaction', true);
+            gtag('set', 'url_passthrough', false);
+            </script>
+            <!-- End Google Consent Mode-->
+        ";
+        $cookiebot_consent_mode = apply_filters( 'mtps_cookiebot_consent_mode', $cookiebot_consent_mode );
+        // phpcs:disable
+        echo $cookiebot_consent_mode;
+        // phpcs:enable
+    }
+
     if ( $gtm_id ) {
         // If we have Cookiebot in use, we need data-cookieconsent attribute for the script.
         $scripts_ignore = $cookiebot_id ? ' data-cookieconsent="ignore"' : '';
@@ -31,15 +69,6 @@ function mtps_head_scripts() {
         $gtm_code = apply_filters( 'mtps_gtm_head_code', $gtm_code, $gtm_id );
         // phpcs:disable
         echo $gtm_code;
-        // phpcs:enable
-    }
-
-    if ( $cookiebot_id && $cookiebot_no_head !== '1' ) {
-        $current_locale = substr( get_locale(), 0, 2 );
-        $cookiebot_code = '<script async id="Cookiebot" data-culture="' . esc_attr( $current_locale ) . '" src="https://consent.cookiebot.com/uc.js" data-cbid="' . esc_attr( $cookiebot_id ) . '" data-blockingmode="auto"></script>';
-        $cookiebot_code = apply_filters( 'mtps_cookiebot_code', $cookiebot_code, $cookiebot_id );
-        // phpcs:disable
-        echo $cookiebot_code;
         // phpcs:enable
     }
 }


### PR DESCRIPTION
Change the order of loading cookiebot and tag manager scripts when both have been inserted via plugin. Also add consent mode code after cookiebot script